### PR TITLE
Use Windows environment variable to retrieve domain name

### DIFF
--- a/fqdn.go
+++ b/fqdn.go
@@ -3,35 +3,42 @@ package fqdn
 import (
 	"net"
 	"os"
+	"runtime"
 	"strings"
 )
 
 // Get Fully Qualified Domain Name
-// returns "unknown" or hostanme in case of error
-func Get() string {
+// returns empty string or hostname if FQDN is unobtainable
+func Get() (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		return "unknown"
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		if dnsDomain := os.Getenv("USERDNSDOMAIN"); dnsDomain != "" {
+			return strings.Join([]string{hostname, dnsDomain}, "."), nil
+		}
 	}
 
 	addrs, err := net.LookupIP(hostname)
 	if err != nil {
-		return hostname
+		return hostname, err
 	}
 
 	for _, addr := range addrs {
 		if ipv4 := addr.To4(); ipv4 != nil {
 			ip, err := ipv4.MarshalText()
 			if err != nil {
-				return hostname
+				return hostname, err
 			}
 			hosts, err := net.LookupAddr(string(ip))
 			if err != nil || len(hosts) == 0 {
-				return hostname
+				return hostname, err
 			}
 			fqdn := hosts[0]
-			return strings.TrimSuffix(fqdn, ".") // return fqdn without trailing dot
+			return strings.TrimSuffix(fqdn, "."), nil // return fqdn without trailing dot
 		}
 	}
-	return hostname
+	return hostname, nil
 }


### PR DESCRIPTION
Wanted to add an option to use the environment variable "USERDNSDOMAIN" on Windows because `net.LookupAddr(string(ip))` seems to always return an empty array. If the environment variable doesn't exist, it will still attempt the rest of the code.
