### PR TITLE
Switch to go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # go-fqdn
-Simple wrapper around `net` and `os` golang standard libraries providing Fully Qualified Domain Name of the machine.
+
+Simple wrapper around `net` and `os` golang standard libraries providing Fully
+Qualified Domain Name of the machine.
 
 ## Usage
-Get the library...
-```
-$ go get github.com/Showmax/go-fqdn
-```
-...and write some code.
+
+This package uses go modules, so just writing code that uses it should be
+enough.
+
 ```
 package main
 
@@ -20,7 +21,20 @@ func main() {
 }
 ```
 
+We can then run it:
+
+```
++   $ go run fqdn.go
+go: finding module for package github.com/Showmax/go-fqdn
+go: found github.com/Showmax/go-fqdn in github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f
+localhost
+```
+
 `fqdn.Get()` returns:
 - machine's FQDN if found.
 - hostname if FQDN is not found.
 - return "unknown" if nothing is found.
+
+## Supported go versions
+
+Current and current - 1 versions of go are supported.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Showmax/go-fqdn
+
+go 1.13


### PR DESCRIPTION
Go world has moved towards go modules see "the way" of dependency
management and we should follow the suit.