### PR TITLE
Update golang version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '~1.17.0'
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -56,13 +56,13 @@ jobs:
           - ubuntu-latest
           - windows-latest
         go:
-          - '1.14'
-          - '1.15'
+          - '~1.16.0'
+          - '~1.17.0'
 
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
 

--- a/fqdn_posix.go
+++ b/fqdn_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package fqdn

--- a/fqdn_test_posix.go
+++ b/fqdn_test_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package fqdn

--- a/fqdn_test_win.go
+++ b/fqdn_test_win.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package fqdn

--- a/fqdn_win.go
+++ b/fqdn_win.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package fqdn

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Showmax/go-fqdn
 
-go 1.15
+go 1.16

--- a/log.go
+++ b/log.go
@@ -1,3 +1,4 @@
+//go:build !DEBUG
 // +build !DEBUG
 
 package fqdn

--- a/log_debug.go
+++ b/log_debug.go
@@ -1,3 +1,4 @@
+//go:build DEBUG
 // +build DEBUG
 
 package fqdn

--- a/util_posix.go
+++ b/util_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package fqdn

--- a/util_win.go
+++ b/util_win.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package fqdn

--- a/util_win_test.go
+++ b/util_win_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package fqdn


### PR DESCRIPTION
Build tags changed between 1.16 and 1.17, so we need to have both
versions for now.